### PR TITLE
chore(deps): upgrade esbuild

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   },
   "peerDependencies": {
     "browserslist": "^4.16.7",
-    "esbuild": ">=0.11.15"
+    "esbuild": "~0.12.19"
   },
   "dependencies": {
     "debug": "^4.3.2",
@@ -43,7 +43,7 @@
     "@types/jest": "^26.0.24",
     "@types/node": "14",
     "browserslist": "^4.16.7",
-    "esbuild": "~0.11.15",
+    "esbuild": "~0.12.19",
     "eslint": "^7.32.0",
     "eslint-plugin-jest": "^24.4.0",
     "husky": "^6.0.0",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   },
   "peerDependencies": {
     "browserslist": "^4.16.5",
-    "esbuild": "~0.11.15"
+    "esbuild": ">=0.11.15"
   },
   "dependencies": {
     "debug": "^4.3.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2193,10 +2193,10 @@ es-to-primitive@^1.2.1:
     is-date-object "^1.0.1"
     is-symbol "^1.0.2"
 
-esbuild@~0.11.15:
-  version "0.11.15"
-  resolved "https://registry.yarnpkg.com/esbuild/-/esbuild-0.11.15.tgz#d92250e1755294f84bc7a83ed191e60baadf7b6a"
-  integrity sha512-Hh40byWZZgYbiLhcoOWiOUIy8yUYQeCEA4F9feWytToD2jGfJ1X4VPf5dsqj6vRL29H3YmFqZsxIJa5q0ifB3g==
+esbuild@~0.12.19:
+  version "0.12.19"
+  resolved "https://registry.yarnpkg.com/esbuild/-/esbuild-0.12.19.tgz#ab849766705a5093df5acd8ec2f6ba2159a38a6c"
+  integrity sha512-5NuT1G6THW7l3fsSCDkcPepn24R0XtyPjKoqKHD8LfhqMXzCdz0mrS9HgO6hIhzVT7zt0T+JGbzCqF5AH8hS9w==
 
 escalade@^3.1.1:
   version "3.1.1"


### PR DESCRIPTION
I'm using this plugin with esbuild `0.12.18`, and npm v7 is unable to resolve the dependency tree, since the peerDependency version here must be `0.11`