### PR TITLE
chore: add repository to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,10 @@
   "description": "Configure esbuild's target based on a browserslist query",
   "version": "0.4.7",
   "author": "Nihal Gonsalves <nihal@nihalgonsalves.com>",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/nihalgonsalves/esbuild-plugin-browserslist.git"
+  }
   "license": "MIT",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",


### PR DESCRIPTION
I was at the [npm page of this package](https://www.npmjs.com/package/esbuild-plugin-browserslist) and couldn't find the repo. With this being set, the package page will have a link to this repo, which adds a bit of convenience.

Thanks 🙏🏿 