### PR TITLE
feat: add support for new "opera" and "ie" esbuild targets

### DIFF
--- a/src/resolveToEsbuildTarget.spec.ts
+++ b/src/resolveToEsbuildTarget.spec.ts
@@ -20,6 +20,8 @@ describe('resolveToEsbuildTarget', () => {
       'firefox 88',
       'node 14.16.0',
       'ios_saf 14.0-14.4',
+      'ios_saf 14.0-14.4',
+      'opera 91',
     ];
 
     const result = resolveToEsbuildTarget(browserslist(query, {}), logFn);
@@ -28,6 +30,7 @@ describe('resolveToEsbuildTarget', () => {
       { target: EsbuildEngine.Firefox, version: '88' },
       { target: EsbuildEngine.IOS, version: '14.0' },
       { target: EsbuildEngine.Node, version: '14.16.0' },
+      { target: EsbuildEngine.Opera, version: '91' },
     ]);
 
     expect(logs).toEqual([]);

--- a/src/resolveToEsbuildTarget.spec.ts
+++ b/src/resolveToEsbuildTarget.spec.ts
@@ -34,7 +34,7 @@ describe('resolveToEsbuildTarget', () => {
   });
 
   it('throws an error on no targets', () => {
-    const query = ['ie 11'];
+    const query = ['ie_mob 11'];
 
     expect(() =>
       resolveToEsbuildTarget(browserslist(query, {}), logFn),
@@ -42,20 +42,20 @@ describe('resolveToEsbuildTarget', () => {
 
     expect(logs).toMatchInlineSnapshot(`
       [
-        "Skipping unknown target: entry=ie 11, browser=ie, version=11",
+        "Skipping unknown target: entry=ie_mob 11, browser=ie_mob, version=11",
       ]
     `);
   });
 
   it('skips unmappable targets', () => {
-    const query = ['chrome 90', 'ie 11'];
+    const query = ['chrome 90', 'ie_mob 11'];
 
     const result = resolveToEsbuildTarget(browserslist(query, {}), logFn);
 
     expect(result).toEqual([{ target: EsbuildEngine.Chrome, version: '90' }]);
     expect(logs).toMatchInlineSnapshot(`
       [
-        "Skipping unknown target: entry=ie 11, browser=ie, version=11",
+        "Skipping unknown target: entry=ie_mob 11, browser=ie_mob, version=11",
       ]
     `);
   });

--- a/src/types.ts
+++ b/src/types.ts
@@ -43,7 +43,7 @@ export enum EsbuildEngine {
   IOS = 'ios',
   Node = 'node',
   Opera = 'opera',
-  Rhino = 'rhino'
+  Rhino = 'rhino',
   Safari = 'safari',
 }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -32,14 +32,18 @@ export enum BrowserslistKind {
   Node = 'node',
 }
 
-/** https://github.com/evanw/esbuild/blob/v0.11.15/internal/compat/js_table.go#L17-L35 */
+/** https://github.com/evanw/esbuild/blob/v0.15.12/internal/compat/js_table.go#L21-L47 */
 export enum EsbuildEngine {
   Chrome = 'chrome',
   Edge = 'edge',
   ES = 'es',
   Firefox = 'firefox',
+  Hermes = 'hermes',
+  IE = 'ie',
   IOS = 'ios',
   Node = 'node',
+  Opera = 'opera',
+  Rhino = 'rhino'
   Safari = 'safari',
 }
 
@@ -53,6 +57,8 @@ export const BrowserslistEsbuildMapping: Partial<
   [BrowserslistKind.Safari]: EsbuildEngine.Safari,
   [BrowserslistKind.iOS]: EsbuildEngine.IOS,
   [BrowserslistKind.Node]: EsbuildEngine.Node,
+  [BrowserslistKind.IE]: EsbuildEngine.IE,
+  [BrowserslistKind.Opera]: EsbuildEngine.Opera,
   // approximate mapping
   [BrowserslistKind.Android]: EsbuildEngine.Chrome,
   [BrowserslistKind.AndroidChrome]: EsbuildEngine.Chrome,


### PR DESCRIPTION
### Background
I saw these warnings even though esbuild [shows it supports `opera`](https://esbuild.github.io/api/#target)

```
[esbuild-plugin-browserslist] Skipping unknown target: entry=opera 92, browser=opera, version=92
[esbuild-plugin-browserslist] Skipping unknown target: entry=opera 91, browser=opera, version=91
```

### PR changes
The minimum supported version of esbuild [is `0.15.12`](https://github.com/nihalgonsalves/esbuild-plugin-browserslist/blob/main/package.json#L36) so this updates the code to use those types.

### Notes
The latest version of esbuild is [`0.15.18` which has a `deno` type](https://github.com/evanw/esbuild/blob/master/internal/compat/js_table.go#L22-L50) but I don't that that changes anything here

I'm not sure if there any other code changes which are needed. Please let me know or hopefully this PR is useful as a starting point