### PR TITLE
fix(peer-deps): upgrade `esbuild` peer dep to new major version ~19

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "esbuild-plugin-browserslist",
   "description": "Configure esbuild's target based on a browserslist query",
-  "version": "0.9.0",
+  "version": "0.8.1",
   "author": "Nihal Gonsalves <nihal@nihalgonsalves.com>",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "esbuild-plugin-browserslist",
   "description": "Configure esbuild's target based on a browserslist query",
-  "version": "0.8.1",
+  "version": "0.9.0",
   "author": "Nihal Gonsalves <nihal@nihalgonsalves.com>",
   "repository": {
     "type": "git",
@@ -27,7 +27,7 @@
   },
   "peerDependencies": {
     "browserslist": "^4.21.8",
-    "esbuild": "~0.18.2"
+    "esbuild": "~0.19.2"
   },
   "dependencies": {
     "debug": "^4.3.4",


### PR DESCRIPTION
Same story as old PR #4.

npm throws an error, when the installed [esbuild](https://github.com/evanw/esbuild) version does not match `package.json > peerDependencies > esbuild` version pattern and we trying to install package without `--legacy-peer-deps` flag.

![2023-08-17T19:52:52,052597000+02:00](https://github.com/nihalgonsalves/esbuild-plugin-browserslist/assets/24324754/d47cb98c-14cd-439a-8af5-1ff05a628a0e)

This fixes it.

BREAKING CHANGE: This is the same breaking change as [v0.8.0](https://github.com/nihalgonsalves/esbuild-plugin-browserslist/releases/tag/v0.8.1) and a fix for that release specifying the wrong peer dependency, but will make this install fail for users of esbuild <0.19.2.
