### PR TITLE
fix: add main field to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "url": "https://github.com/nihalgonsalves/esbuild-plugin-browserslist.git"
   },
   "license": "MIT",
+  "main": "./dist/index.js",
   "exports": {
     "types": "./dist/index.d.ts",
     "default": "./dist/index.js"


### PR DESCRIPTION
This is a suggested fix to improve compat with linting - see reasoning below.

When using `eslint-plugin-import` for eslint (a reasonably popular choice, I believe), it will give false positives when encountering packages that rely on `exports` in package.json.

There’s [a long-standing issue](https://github.com/import-js/eslint-plugin-import/issues/1810) to fix this, but as of yet it is not done, leading to users having to manually ignore those errors.

However, in the scenario where the exported entry point is pointing to the main file of the package, it’s enough to just list that file under the `main` key to make the false positive go away.